### PR TITLE
Implement order CSV export and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+SQL_USER=your_user
+SQL_PASSWORD=your_password
+SQL_SERVER=localhost
+SQL_PORT=1433
+SQL_DATABASE=p21

--- a/p21-api/openapi.yaml
+++ b/p21-api/openapi.yaml
@@ -1,0 +1,97 @@
+openapi: 3.0.3
+info:
+  title: P21 API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3000
+paths:
+  /inventory:
+    get:
+      summary: List inventory items
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+        - in: query
+          name: paging
+          schema:
+            type: boolean
+        - in: query
+          name: page
+          schema:
+            type: integer
+        - in: query
+          name: order
+          schema:
+            type: string
+            enum: [asc, desc]
+        - in: query
+          name: inactive
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Inventory list
+  /inventory/{item_id}:
+    get:
+      summary: Get item by id
+      parameters:
+        - in: path
+          name: item_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Item details
+        '404':
+          description: Item not found
+  /orders:
+    post:
+      summary: Export order to CSV
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [customer_id, sales_location_id, srx_order_id, lines]
+              properties:
+                customer_id:
+                  type: string
+                sales_location_id:
+                  type: string
+                srx_order_id:
+                  type: string
+                notes:
+                  type: string
+                lines:
+                  type: array
+                  items:
+                    type: object
+                    required: [item_id, qty]
+                    properties:
+                      item_id:
+                        type: string
+                      qty:
+                        type: integer
+                      notes:
+                        type: string
+      responses:
+        '200':
+          description: CSV paths returned
+  /orders/{order_id}:
+    get:
+      summary: Get export status
+      parameters:
+        - in: path
+          name: order_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Order status
+        '404':
+          description: Order not found

--- a/p21-api/order_log.sql
+++ b/p21-api/order_log.sql
@@ -1,0 +1,8 @@
+CREATE TABLE order_log (
+  id INT IDENTITY(1,1) PRIMARY KEY,
+  srx_order_id VARCHAR(50) NOT NULL,
+  order_id VARCHAR(50) NULL,
+  status VARCHAR(20) NOT NULL,
+  export_path VARCHAR(255) NULL,
+  created_at DATETIME NOT NULL DEFAULT GETDATE()
+);

--- a/p21-api/package.json
+++ b/p21-api/package.json
@@ -7,9 +7,11 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.18.2",
+    "axios": "^1.6.7",
     "dotenv": "^16.0.3",
+    "express": "^4.18.2",
     "mssql": "^10.0.1",
-    "axios": "^1.6.7"
+    "swagger-ui-express": "^4.7.1",
+    "yamljs": "^0.3.0"
   }
 }

--- a/p21-api/routes/orders.js
+++ b/p21-api/routes/orders.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const router = express.Router();
+const { sql, config } = require('../db');
+const { generateFiles } = require('../utils/csvGenerator');
+const path = require('path');
+const fs = require('fs');
+
+// POST /orders
+router.post('/', async (req, res) => {
+  const { customer_id, sales_location_id, srx_order_id, notes, lines } = req.body;
+  if (!customer_id || !sales_location_id || !srx_order_id || !Array.isArray(lines) || lines.length === 0) {
+    return res.status(400).json({ error: 'Invalid order payload' });
+  }
+
+  try {
+    const csvInfo = generateFiles({ customer_id, sales_location_id, srx_order_id, notes, lines });
+
+    await sql.connect(config);
+    const request = new sql.Request();
+    request.input('srx_order_id', sql.VarChar, srx_order_id);
+    request.input('status', sql.VarChar, 'exported');
+    request.input('export_path', sql.VarChar, csvInfo.exportDir);
+    await request.query(`
+      INSERT INTO order_log (srx_order_id, status, export_path, created_at)
+      VALUES (@srx_order_id, @status, @export_path, GETDATE());
+    `);
+
+    res.json({
+      message: 'Order exported',
+      files: {
+        header: path.relative(process.cwd(), csvInfo.headerPath),
+        line: path.relative(process.cwd(), csvInfo.linePath),
+        headerNotes: csvInfo.headerNotesPath ? path.relative(process.cwd(), csvInfo.headerNotesPath) : null,
+        lineNotes: csvInfo.lineNotesPath ? path.relative(process.cwd(), csvInfo.lineNotesPath) : null
+      }
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /orders/:order_id
+router.get('/:order_id', async (req, res) => {
+  const id = req.params.order_id;
+  try {
+    await sql.connect(config);
+    const request = new sql.Request();
+    request.input('id', sql.VarChar, id);
+    const result = await request.query(`
+      SELECT TOP (1) * FROM order_log WHERE srx_order_id = @id OR order_id = @id ORDER BY created_at DESC;
+    `);
+    if (result.recordset.length === 0) {
+      return res.status(404).json({ error: 'Order not found' });
+    }
+    res.json(result.recordset[0]);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/p21-api/server.js
+++ b/p21-api/server.js
@@ -1,13 +1,20 @@
 const express = require('express');
 require('dotenv').config();
+const path = require('path');
+const swaggerUi = require('swagger-ui-express');
+const YAML = require('yamljs');
 
 const app = express();
 app.use(express.json());
 
+const swaggerDocument = YAML.load(path.join(__dirname, 'openapi.yaml'));
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+
 // Routes
 app.use('/inventory', require('./routes/inventory'));
-app.use('/salesorders', require('./routes/salesorders'));
 app.use('/pricing', require('./routes/pricing'));
+app.use('/salesorders', require('./routes/salesorders'));
+app.use('/orders', require('./routes/orders'));
 
 // DEBUG fallback route (handles unmatched routes safely)
 app.all('*', (req, res) => {

--- a/p21-api/utils/csvGenerator.js
+++ b/p21-api/utils/csvGenerator.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+
+function buildLine(fields) {
+  return fields.map(f => f != null ? String(f) : '').join('|') + '\n';
+}
+
+function generateFiles(order) {
+  const timestamp = Date.now();
+  const dir = path.join(__dirname, '..', 'exports', `order-${order.srx_order_id}-${timestamp}`);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const headerPath = path.join(dir, 'orderquoteheader.txt');
+  const linePath = path.join(dir, 'orderquoteline.txt');
+  const headerNotesPath = path.join(dir, 'orderquoteheadernotes.txt');
+  const lineNotesPath = path.join(dir, 'orderquotelinenotes.txt');
+
+  const headerLines = [];
+  const lineLines = [];
+  const headerNotesLines = [];
+  const lineNotesLines = [];
+
+  // Basic header record
+  headerLines.push(buildLine([
+    order.srx_order_id,
+    order.customer_id,
+    order.sales_location_id,
+    '' // placeholder for additional fields
+  ]));
+
+  if (order.notes) {
+    headerNotesLines.push(buildLine([
+      order.srx_order_id,
+      order.notes
+    ]));
+  }
+
+  order.lines.forEach((l, idx) => {
+    lineLines.push(buildLine([
+      order.srx_order_id,
+      idx + 1,
+      l.item_id,
+      l.qty
+    ]));
+
+    if (l.notes) {
+      lineNotesLines.push(buildLine([
+        order.srx_order_id,
+        idx + 1,
+        l.notes
+      ]));
+    }
+  });
+
+  fs.writeFileSync(headerPath, headerLines.join(''));
+  fs.writeFileSync(linePath, lineLines.join(''));
+  if (headerNotesLines.length) fs.writeFileSync(headerNotesPath, headerNotesLines.join(''));
+  if (lineNotesLines.length) fs.writeFileSync(lineNotesPath, lineNotesLines.join(''));
+
+  return {
+    headerPath,
+    linePath,
+    headerNotesPath: headerNotesLines.length ? headerNotesPath : null,
+    lineNotesPath: lineNotesLines.length ? lineNotesPath : null,
+    exportDir: dir
+  };
+}
+
+module.exports = { generateFiles };


### PR DESCRIPTION
## Summary
- add Swagger spec with `/orders` endpoints
- generate Prophet 21 order CSV files
- log orders in SQL Server via `order_log` table
- expose Swagger UI at `/docs`
- provide sample `.env.example`

## Testing
- `node -v`
- `node p21-api/server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686d32abf4808331b71f35e73475283c