### PR TITLE
Add API usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,103 @@
+# P21 API
+
+This repository contains a minimal Express server exposing a handful of routes used by SRX/P21 integrations.
+
+## Setup
+
+1. Install Node.js 14+.
+2. Copy `.env.example` to `.env` and update the SQL connection details.
+3. Install dependencies and start the API from the `p21-api` directory:
+   ```bash
+   cd p21-api
+   npm install
+   PORT=3000 npm start
+   ```
+   The port can be changed with the `PORT` environment variable.
+4. Access the Swagger UI at `http://localhost:<PORT>/docs` for interactive API documentation.
+
+## Routes
+
+### `GET /inventory`
+List inventory items. Supports optional query parameters:
+- `limit` – number of results to return (default `100`)
+- `page` – page number when `paging=true`
+- `paging` – when `true`, enables SQL paging
+- `order` – `asc` or `desc` (default `asc`)
+- `inactive` – include inactive items (`true` or `false`)
+
+Example:
+```bash
+curl "http://localhost:3000/inventory?limit=5&paging=true&page=2"
+```
+
+### `GET /inventory/{item_id}`
+Returns a single item record.
+
+Example:
+```bash
+curl http://localhost:3000/inventory/ABC123
+```
+
+### `GET /pricing/{item_id}`
+Returns pricing information for an item (placeholder implementation).
+
+Example:
+```bash
+curl http://localhost:3000/pricing/ABC123
+```
+
+### `POST /salesorders`
+Creates a sales order (currently a placeholder).
+
+Example payload:
+```bash
+curl -X POST http://localhost:3000/salesorders \
+  -H "Content-Type: application/json" \
+  -d '{"customer_id":"CUST1","lines":[{"item_id":"ABC123","qty":1}]}'
+```
+
+### `GET /salesorders/{order_id}`
+Retrieves the status of a sales order.
+
+```bash
+curl http://localhost:3000/salesorders/ORDER123
+```
+
+### `POST /orders`
+Exports an order to CSV files. Required payload fields:
+`customer_id`, `sales_location_id`, `srx_order_id`, and an array of `lines` with `item_id` and `qty`.
+Optional `notes` can be included on the header or line items.
+
+Example:
+```bash
+curl -X POST http://localhost:3000/orders \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customer_id": "CUST1",
+    "sales_location_id": "LOC1",
+    "srx_order_id": "SO123",
+    "notes": "Urgent",
+    "lines": [
+      { "item_id": "ABC123", "qty": 2 }
+    ]
+  }'
+```
+
+### `GET /orders/{order_id}`
+Check the export status of a previously created order.
+
+```bash
+curl http://localhost:3000/orders/SO123
+```
+
+## Top-Level `server.js`
+There is also a simple `server.js` in the project root that mounts the `salesorders` route under `/api`. It is mainly for quick testing:
+
+```bash
+node server.js
+# or
+PORT=4000 node server.js
+```
+
+Access it at `http://localhost:<PORT>/api`.
+

--- a/p21-api/server.js
+++ b/p21-api/server.js
@@ -25,5 +25,6 @@ app.all('*', (req, res) => {
   });
 });
 
-const PORT = 3000;
+// Allow the port to be configured via the environment for flexibility
+const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`P21 API running on port ${PORT}`));

--- a/server.js
+++ b/server.js
@@ -1,10 +1,13 @@
 const express = require('express');
 const app = express();
-const salesOrderRoute = require('./api/routes/salesorder');
+
+// The routes live inside the p21-api folder. The previous path was broken.
+const salesOrderRoute = require('./p21-api/routes/salesorders');
 
 app.use(express.json());
 app.use('/api', salesOrderRoute);
 
-app.listen(3000, () => {
-  console.log('API running on port 3000');
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`API running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- document setup steps and example calls for each route

## Testing
- `node --check server.js`
- `node --check p21-api/server.js`


------
https://chatgpt.com/codex/tasks/task_e_686d56c7957c8331855bef4d1578ae2d