### PR TITLE
Add env example for SQL and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a minimal Express server exposing a handful of routes u
 ## Setup
 
 1. Install Node.js 14+.
-2. Copy `.env.example` to `.env` and update the SQL connection details.
+2. Copy `p21-api/.env.example` to `p21-api/.env` and fill in your SQL connection details.
 3. Install dependencies and start the API from the `p21-api` directory:
    ```bash
    cd p21-api

--- a/p21-api/.env.example
+++ b/p21-api/.env.example
@@ -1,0 +1,5 @@
+SQL_USER=your_user
+SQL_PASSWORD=your_password
+SQL_SERVER=localhost
+SQL_PORT=1433
+SQL_DATABASE=your_database


### PR DESCRIPTION
## Summary
- provide `p21-api/.env.example` with SQL connection placeholders
- clarify setup instructions in `README.md`

## Testing
- `npm install` *(fails: No matching version found for swagger-ui-express@^4.7.1)*

------
https://chatgpt.com/codex/tasks/task_e_686e8cc6068883318ddbd4116d9c72ae