### PR TITLE
Add status logic to sales order route

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ curl -X POST http://localhost:3000/salesorders \
 ```
 
 ### `GET /salesorders/{order_id}`
-Retrieves the status of a sales order.
+Retrieves the status of a sales order. The response includes header information
+with a computed `status` field as well as line items each with their own
+`status`.
 
 ```bash
 curl http://localhost:3000/salesorders/ORDER123

--- a/p21-api/openapi.yaml
+++ b/p21-api/openapi.yaml
@@ -95,4 +95,18 @@ paths:
           description: Order status
         '404':
           description: Order not found
+  /salesorders/{order_id}:
+    get:
+      summary: Get sales order status
+      parameters:
+        - in: path
+          name: order_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Sales order header and lines returned with status fields
+        '404':
+          description: Order not found
 

--- a/p21-api/routes/salesorders.js
+++ b/p21-api/routes/salesorders.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const router = express.Router();
+const { sql, config } = require('../db');
+const { computeHeaderStatus, computeLineStatus } = require('../utils/orderStatus');
 
 // POST /salesorders
 router.post('/', (req, res) => {
@@ -7,8 +9,60 @@ router.post('/', (req, res) => {
 });
 
 // GET /salesorders/:order_id
-router.get('/:order_id', (req, res) => {
-  res.json({ message: `Status of order ${req.params.order_id}` });
+router.get('/:order_id', async (req, res) => {
+  const rawId = req.params.order_id;
+  const orderId = parseInt(rawId, 10);
+
+  if (Number.isNaN(orderId)) {
+    return res.status(400).json({ error: 'Invalid order_id' });
+  }
+
+  try {
+    await sql.connect(config);
+
+    const headerRequest = new sql.Request();
+    headerRequest.input('orderId', sql.Int, orderId);
+    const headerResult = await headerRequest.query(`
+      SELECT order_no, customer_id, order_date, ship2_name, ship2_add1, po_no,
+             job_price_hdr_uid, delete_flag, completed, company_id, date_created,
+             po_no_append, location_id, carrier_id, address_id, taker, job_name,
+             approved, cancel_flag, promise_date, ups_code, expedite_date,
+             oe_hdr.validation_status
+      FROM oe_hdr
+      WHERE order_no = @orderId
+    `);
+
+    if (headerResult.recordset.length === 0) {
+      return res.status(404).json({ error: 'Order not found' });
+    }
+
+    const lineRequest = new sql.Request();
+    lineRequest.input('orderId', sql.Int, orderId);
+    const lineResult = await lineRequest.query(`
+      SELECT order_no, qty_ordered, delete_flag, line_no, complete, disposition,
+             qty_allocated, qty_on_pick_tickets, qty_invoiced, required_date,
+             unit_size, unit_quantity, customer_part_number, cancel_flag,
+             qty_canceled
+      FROM oe_line
+      WHERE order_no = @orderId
+    `);
+
+    const header = headerResult.recordset[0];
+    header.status = computeHeaderStatus(header);
+
+    const lines = lineResult.recordset.map((ln) => ({
+      ...ln,
+      status: computeLineStatus(ln)
+    }));
+
+    res.json({
+      header,
+      lines
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
 });
 
 module.exports = router;

--- a/p21-api/utils/orderStatus.js
+++ b/p21-api/utils/orderStatus.js
@@ -1,0 +1,31 @@
+function computeHeaderStatus(header) {
+  const del = (header.delete_flag || '').trim().toUpperCase();
+  const cancel = (header.cancel_flag || '').trim().toUpperCase();
+  const completed = (header.completed || '').trim().toUpperCase();
+  const approved = (header.approved || '').trim().toUpperCase();
+  if (cancel === 'Y') return 'Canceled';
+  if (del === 'Y') return 'Deleted';
+  if (completed === 'Y' && approved === 'Y') return 'Completed';
+  if (approved === 'N') return 'Unapproved';
+  return 'Open';
+}
+
+function computeLineStatus(line) {
+  const del = (line.delete_flag || '').trim().toUpperCase();
+  const cancel = (line.cancel_flag || '').trim().toUpperCase();
+  const qtyOrdered = Number(line.qty_ordered) || 0;
+  const qtyAllocated = Number(line.qty_allocated) || 0;
+  const qtyInvoiced = Number(line.qty_invoiced) || 0;
+  const qtyCanceled = Number(line.qty_canceled) || 0;
+  if (qtyInvoiced === qtyOrdered && qtyOrdered > 0) return 'Fulfilled';
+  if (qtyInvoiced > 0 && qtyInvoiced < qtyOrdered) return 'Partially Fulfilled';
+  if (cancel === 'Y') return 'Canceled';
+  if (del === 'Y') return 'Deleted';
+  if (qtyAllocated > 0) return 'In Progress';
+  if (qtyOrdered > 0 && qtyAllocated === 0 && qtyInvoiced === 0 && qtyCanceled === 0) {
+    return 'New';
+  }
+  return 'Open';
+}
+
+module.exports = { computeHeaderStatus, computeLineStatus };


### PR DESCRIPTION
## Summary
- compute header and line status for `/salesorders/{order_id}`
- expose status info through the API and docs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ea0ea81008331aa501906f1305f1c