### PR TITLE
Fix reference for order status endpoint

### DIFF
--- a/p21-api/openapi.yaml
+++ b/p21-api/openapi.yaml
@@ -105,7 +105,7 @@ paths:
       description: |
         Retrieves a sales order header and its lines from P21. Each record is
         augmented with a `status` field derived from various flag columns.
-        Implemented in `routes/salesorders.js`.
+        Implemented in `routes/orders.js`.
       parameters:
         - in: path
           name: order_id


### PR DESCRIPTION
## Summary
- update reference to correct orders route

## Testing
- `grep -n "routes/orders.js" -n p21-api/openapi.yaml`

------
https://chatgpt.com/codex/tasks/task_e_686eba05da54833189cc77047a2fecec