### PR TITLE
Remove unused fs import

### DIFF
--- a/p21-api/routes/orders.js
+++ b/p21-api/routes/orders.js
@@ -3,7 +3,6 @@ const router = express.Router();
 const { sql, config } = require('../db');
 const { generateFiles } = require('../utils/csvGenerator');
 const path = require('path');
-const fs = require('fs');
 
 // POST /orders
 router.post('/', async (req, res) => {


### PR DESCRIPTION
## Summary
- remove unused `fs` import from `orders.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686eba14c5588331afdd1d49aa25f7c3