### PR TITLE
Load env file relative to API directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a minimal Express server exposing a handful of routes u
 
 1. Install Node.js 14+.
 
-2. Copy `p21-api/.env.example` to `p21-api/.env` and update the SQL connection details.
+2. Copy `p21-api/.env.example` to `p21-api/.env` and update the SQL connection details. Environment variables will be loaded from this file automatically.
 
 3. Install dependencies and start the API from the `p21-api` directory:
    ```bash

--- a/p21-api/db.js
+++ b/p21-api/db.js
@@ -1,5 +1,6 @@
+const path = require('path');
 const sql = require('mssql');
-require('dotenv').config();
+require('dotenv').config({ path: path.join(__dirname, '.env') });
 
 const config = {
   user: process.env.SQL_USER,

--- a/p21-api/server.js
+++ b/p21-api/server.js
@@ -1,6 +1,6 @@
 const express = require('express');
-require('dotenv').config();
 const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env') });
 const swaggerUi = require('swagger-ui-express');
 const YAML = require('yamljs');
 


### PR DESCRIPTION
## Summary
- ensure `dotenv` loads `.env` from the API folder in `server.js` and `db.js`
- document automatic loading of `p21-api/.env`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686eba21e5a083319816e7079794278d