### PR TITLE
Support order_ref in order status lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,18 @@ curl -X POST http://localhost:3000/orders \
 ```
 
 ### `GET /orders/{order_id}`
-Retrieves the status of an existing order from P21. The response includes header
-information with a computed `status` field along with each line item and its
-individual `status`.
+Retrieves the status of an existing order from P21. The `{order_id}` can be the
+numeric `order_no` or the `order_ref` (formerly returned as `job_name`). The
+response includes header information with a computed `status` field along with
+each line item and its individual `status`. The header field `order_ref` maps to
+the `job_name` column in P21.
 
 ```bash
+# Lookup by order number
 curl http://localhost:3000/orders/123456
+
+# Lookup by order reference
+curl http://localhost:3000/orders/REF-001
 ```
 
 ## Standalone `server.js`

--- a/p21-api/openapi.yaml
+++ b/p21-api/openapi.yaml
@@ -103,15 +103,16 @@ paths:
     get:
       summary: Get sales order status
       description: |
-        Retrieves a sales order header and its lines from P21. Each record is
-        augmented with a `status` field derived from various flag columns.
-        Implemented in `routes/salesorders.js`.
+        Retrieves a sales order header and its lines from P21. The `order_id`
+        can be either the numeric `order_no` or the `order_ref` associated with
+        the order. Each record is augmented with a `status` field derived from
+        various flag columns. Implemented in `routes/orders.js`.
       parameters:
         - in: path
           name: order_id
           required: true
           schema:
-            type: integer
+            type: string
       responses:
         '200':
           description: Sales order header and lines returned with status fields

--- a/p21-api/routes/orders.js
+++ b/p21-api/routes/orders.js
@@ -42,18 +42,12 @@ router.post('/', async (req, res) => {
 // GET /orders/:order_id
 router.get('/:order_id', async (req, res) => {
   const rawId = req.params.order_id;
-  const orderId = parseInt(rawId, 10);
-
-  if (Number.isNaN(orderId)) {
-    return res.status(400).json({ error: 'Invalid order_id' });
-  }
-
   try {
     await sql.connect(config);
 
     const headerRequest = new sql.Request();
-    headerRequest.input('orderId', sql.Int, orderId);
-    const headerResult = await headerRequest.query(`
+    headerRequest.input('orderId', sql.VarChar, rawId);
+    const headerQuery = `
       SELECT order_no, customer_id, order_date, ship2_name, ship2_add1, po_no,
              job_price_hdr_uid, delete_flag, completed, company_id, date_created,
              po_no_append, location_id, carrier_id, address_id, taker, job_name,
@@ -67,15 +61,23 @@ router.get('/:order_id', async (req, res) => {
                ELSE 'Open'
              END AS status
       FROM oe_hdr
-      WHERE order_no = @orderId
-    `);
+      WHERE order_no = TRY_CAST(@orderId AS INT)
+         OR job_name = @orderId`;
+
+    const headerResult = await headerRequest.query(headerQuery);
 
     if (headerResult.recordset.length === 0) {
       return res.status(404).json({ error: 'Order not found' });
     }
 
+    const orderNumberForLines = headerResult.recordset[0]?.order_no;
+
+    if (!orderNumberForLines) {
+      return res.status(404).json({ error: 'Order not found' });
+    }
+
     const lineRequest = new sql.Request();
-    lineRequest.input('orderId', sql.Int, orderId);
+    lineRequest.input('orderId', sql.Int, orderNumberForLines);
     const lineResult = await lineRequest.query(`
       SELECT order_no, qty_ordered, delete_flag, line_no, complete, disposition,
              qty_allocated, qty_on_pick_tickets, qty_invoiced, required_date,
@@ -94,7 +96,9 @@ router.get('/:order_id', async (req, res) => {
       WHERE order_no = @orderId
     `);
 
-    const header = headerResult.recordset[0];
+    const headerData = headerResult.recordset[0];
+    const { job_name, ...rest } = headerData;
+    const header = { ...rest, order_ref: job_name };
     const lines = lineResult.recordset;
 
     res.json({


### PR DESCRIPTION
## Summary
- rename `job_name` field in order status response to `order_ref`
- allow `GET /orders/{order_id}` to accept either an `order_no` or an `order_ref`
- reduce duplicate SQL with a single query filtering by `order_no` or `job_name`
- document new behaviour in README and OpenAPI spec

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ecb3b1aa08331839bdee36980fa09