### PR TITLE
Update order API with new required fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,19 +80,19 @@ curl http://localhost:3000/pricing/ABC123
 
 ### `POST /orders`
 Exports a sales order to CSV files. Required fields are `customer_id`,
-`sales_location_id`, `srx_order_id` and an array of line items with `item_id`
+`company_id`, `sales_location_id`, `taker`, `order_ref`, `approved`,
+`ship_to_id`, `contract_number` and an array of line items with `item_id`
 and `qty`. Optional `notes` may be provided on the header or individual lines.
-The response returns the generated file paths:
+The response returns the generated file paths and the import set number:
 
 ```json
 {
   "message": "Order exported",
   "files": {
-    "header": "<header.csv>",
-    "line": "<line.csv>",
-    "headerNotes": null,
-    "lineNotes": null
-  }
+    "headerFile": "<header.txt>",
+    "linesFile": "<lines.txt>"
+  },
+  "importSetNumber": "ABC12345"
 }
 ```
 
@@ -102,8 +102,13 @@ curl -X POST http://localhost:3000/orders \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "CUST1",
+    "company_id": "COMP1",
     "sales_location_id": "LOC1",
-    "srx_order_id": "SO123",
+    "taker": "JDOE",
+    "order_ref": "SO123",
+    "approved": "Y",
+    "ship_to_id": "SHIP1",
+    "contract_number": "CNTR123",
     "notes": "Urgent",
     "lines": [
       { "item_id": "ABC123", "qty": 2 }

--- a/p21-api/openapi.yaml
+++ b/p21-api/openapi.yaml
@@ -81,13 +81,24 @@ paths:
           application/json:
             schema:
               type: object
-              required: [customer_id, sales_location_id, srx_order_id, lines]
+              required:
+                [customer_id, company_id, sales_location_id, taker, order_ref, approved, ship_to_id, contract_number, lines]
               properties:
                 customer_id:
                   type: string
+                company_id:
+                  type: string
                 sales_location_id:
                   type: string
-                srx_order_id:
+                taker:
+                  type: string
+                order_ref:
+                  type: string
+                approved:
+                  type: string
+                ship_to_id:
+                  type: string
+                contract_number:
                   type: string
                 notes:
                   type: string
@@ -105,7 +116,7 @@ paths:
                         type: string
       responses:
         '200':
-          description: CSV paths returned
+          description: CSV file locations and import set number returned
           content:
             application/json:
               schema:
@@ -198,16 +209,12 @@ components:
         files:
           type: object
           properties:
-            header:
+            headerFile:
               type: string
-            line:
+            linesFile:
               type: string
-            headerNotes:
-              type: string
-              nullable: true
-            lineNotes:
-              type: string
-              nullable: true
+        importSetNumber:
+          type: string
     OrderHeader:
       type: object
       properties:

--- a/p21-api/order_log.sql
+++ b/p21-api/order_log.sql
@@ -1,6 +1,6 @@
 CREATE TABLE order_log (
   id INT IDENTITY(1,1) PRIMARY KEY,
-  srx_order_id VARCHAR(50) NOT NULL,
+  order_ref VARCHAR(50) NOT NULL,
   order_id VARCHAR(50) NULL,
   status VARCHAR(20) NOT NULL,
   export_path VARCHAR(255) NULL,


### PR DESCRIPTION
## Summary
- add company_id, taker, approved, ship_to_id and contract_number to POST payload
- map the new fields to header and line records when generating order exports
- document the new parameters and update OpenAPI schema
- rename `srx_order_id` parameter to `order_ref`

## Testing
- `node --check p21-api/routes/orders.js`
- `node --check p21-api/utils/csvGenerator.js`


------
https://chatgpt.com/codex/tasks/task_e_68710c9300a08331a2c4ef62fea3da0b