### PR TITLE
Add suppliers API endpoint

### DIFF
--- a/p21-api/openapi.yaml
+++ b/p21-api/openapi.yaml
@@ -5,6 +5,51 @@ info:
 servers:
   - url: http://localhost:3000
 paths:
+  /v1/ap/suppliers:
+    get:
+      summary: List AP suppliers
+      description: |
+        Returns a paginated list of suppliers from P21. Results can be filtered by
+        company and by the most recent change to either the vendor or its payment terms.
+        Implemented in `routes/v1/ap/suppliers.js`.
+      parameters:
+        - in: query
+          name: updated_since
+          schema:
+            type: string
+            format: date-time
+          description: >-
+            Optional ISO 8601 timestamp. When supplied, only suppliers whose vendor or
+            payment terms were modified on or after this timestamp are returned.
+        - in: query
+          name: company
+          schema:
+            type: string
+          description: Filter to a specific P21 company id.
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Results page number (1-indexed).
+        - in: query
+          name: page_size
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 2000
+            default: 500
+          description: Number of records to include per page (max 2000).
+      responses:
+        '200':
+          description: Supplier list with pagination metadata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SupplierListResponse'
+        '400':
+          description: Invalid query parameter supplied
   /inventory:
     get:
       summary: List inventory items
@@ -184,6 +229,117 @@ components:
         totalCount:
           type: integer
         page:
+          type: integer
+        totalPages:
+          type: integer
+    SupplierTerms:
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        discountPercent:
+          type: number
+          nullable: true
+        discountDays:
+          type: integer
+          nullable: true
+        netDays:
+          type: integer
+          nullable: true
+    Supplier:
+      type: object
+      properties:
+        erpSourceId:
+          type: string
+          nullable: true
+        externalSystemId:
+          type: string
+          nullable: true
+        isActive:
+          type: boolean
+        companyId:
+          type: string
+          nullable: true
+        currencyCode:
+          type: string
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        paymentTerm:
+          type: string
+          nullable: true
+        supplierId:
+          type: string
+          nullable: true
+        ledgerDimension1:
+          type: string
+          nullable: true
+        taxDimension1:
+          type: string
+          nullable: true
+        clearance1Dimension1:
+          type: string
+          nullable: true
+        taxIndicator1:
+          type: string
+          nullable: true
+        taxIndicator2:
+          type: string
+          nullable: true
+        streetAddress:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+        zip:
+          type: string
+          nullable: true
+        country:
+          type: string
+          nullable: true
+        telephone:
+          type: string
+          nullable: true
+        fax:
+          type: string
+          nullable: true
+        homepage:
+          type: string
+          nullable: true
+        emailAddress:
+          type: string
+          nullable: true
+        state:
+          type: string
+          nullable: true
+        isProcurable:
+          type: boolean
+        prepayment:
+          type: boolean
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+        terms:
+          $ref: '#/components/schemas/SupplierTerms'
+    SupplierListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Supplier'
+        page:
+          type: integer
+        pageSize:
+          type: integer
+        total:
           type: integer
         totalPages:
           type: integer

--- a/p21-api/routes/v1/ap/suppliers.js
+++ b/p21-api/routes/v1/ap/suppliers.js
@@ -1,0 +1,196 @@
+const express = require('express');
+const router = express.Router();
+const { sql, config } = require('../../../db');
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 500;
+const MAX_PAGE_SIZE = 2000;
+
+const parsePositiveInt = (value, defaultValue) => {
+  const parsed = parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return defaultValue;
+  }
+  return parsed;
+};
+
+const normalizeDate = (value) => {
+  if (!value) {
+    return null;
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const formatSupplierRecord = (row) => {
+  const companyToken = row.company_id ? `company[${row.company_id}]` : null;
+  const supplierId = row.supplierId ? String(row.supplierId).trim() : null;
+  const addressParts = [row.address1, row.address2].filter((part) => part && part.trim());
+  const latestModified = [row.date_last_modified, row.terms_date_last_modified]
+    .map(normalizeDate)
+    .filter(Boolean)
+    .sort((a, b) => b - a)[0];
+  const ledgerDimension = companyToken && row.ap_account_no
+    ? `${companyToken};DIMENSION1;${row.ap_account_no}`
+    : null;
+  const taxDimension = companyToken && row.default_purch_acct_no
+    ? `${companyToken};DIMENSION1;${row.default_purch_acct_no}`
+    : null;
+
+  return {
+    erpSourceId: process.env.ERP_SOURCE_ID || 'P21',
+    externalSystemId: companyToken && supplierId ? `${companyToken};${supplierId}` : supplierId,
+    isActive: row.delete_flag !== 'Y',
+    companyId: companyToken,
+    currencyCode: row.currency_code || null,
+    name: row.name || null,
+    paymentTerm: companyToken && row.terms_id ? `${companyToken};${row.terms_id}` : row.terms_id || null,
+    supplierId,
+    ledgerDimension1: ledgerDimension,
+    taxDimension1: taxDimension,
+    clearance1Dimension1: ledgerDimension,
+    taxIndicator1: null,
+    taxIndicator2: null,
+    streetAddress: addressParts.join(' ').trim() || null,
+    city: row.city || null,
+    zip: row.postalcode || null,
+    country: row.country || null,
+    telephone: row.phone || null,
+    fax: row.fax || null,
+    homepage: null,
+    emailAddress: row.email_address || null,
+    state: row.state || null,
+    isProcurable: row.delete_flag !== 'Y',
+    prepayment: row.prepayment === 'Y',
+    updatedAt: latestModified ? latestModified.toISOString() : null,
+    terms: {
+      id: row.terms_id || null,
+      description: row.terms_desc || null,
+      discountPercent: row.discount_pct,
+      discountDays: row.discount_days,
+      netDays: row.net_days
+    }
+  };
+};
+
+router.get('/', async (req, res) => {
+  const page = parsePositiveInt(req.query.page, DEFAULT_PAGE);
+  let pageSize = parsePositiveInt(req.query.page_size, DEFAULT_PAGE_SIZE);
+  if (pageSize > MAX_PAGE_SIZE) {
+    pageSize = MAX_PAGE_SIZE;
+  }
+
+  const offset = (page - 1) * pageSize;
+
+  const updatedSinceParam = req.query.updated_since;
+  const companyParam = typeof req.query.company === 'string' ? req.query.company.trim() : null;
+
+  let updatedSinceDate = null;
+  if (updatedSinceParam) {
+    updatedSinceDate = new Date(updatedSinceParam);
+    if (Number.isNaN(updatedSinceDate.getTime())) {
+      return res.status(400).json({ error: 'Invalid updated_since parameter. Expecting ISO 8601 date.' });
+    }
+  }
+
+  try {
+    await sql.connect(config);
+
+    const filters = [];
+    if (updatedSinceDate) {
+      filters.push('(vendor.date_last_modified >= @updatedSince OR terms.date_last_modified >= @updatedSince)');
+    }
+    if (companyParam) {
+      filters.push('vendor.company_id = @company');
+    }
+
+    const whereClause = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+
+    const dataRequest = new sql.Request();
+    dataRequest.input('offset', sql.Int, offset);
+    dataRequest.input('pageSize', sql.Int, pageSize);
+    if (updatedSinceDate) {
+      dataRequest.input('updatedSince', sql.DateTime2, updatedSinceDate);
+    }
+    if (companyParam) {
+      dataRequest.input('company', sql.VarChar, companyParam);
+    }
+
+    const dataQuery = `
+      SELECT
+        vendor.vendor_id AS supplierId,
+        vendor.company_id,
+        vendor.ap_account_no,
+        vendor.date_last_modified,
+        'Y' AS prepayment,
+        vendor.currency_id,
+        CASE vendor.currency_id
+          WHEN 1 THEN 'CAD'
+          WHEN 3 THEN 'USD'
+          WHEN 4 THEN 'EUR'
+          WHEN 6 THEN 'CNY'
+          ELSE 'UNKNOWN'
+        END AS currency_code,
+        vendor.vendor_name AS name,
+        address.mail_address1 AS address1,
+        address.mail_address2 AS address2,
+        address.mail_city AS city,
+        address.mail_state AS state,
+        address.mail_postal_code AS postalcode,
+        address.mail_country AS country,
+        address.central_phone_number AS phone,
+        address.central_fax_number AS fax,
+        address.email_address,
+        vendor.default_purch_acct_no,
+        address.delete_flag,
+        terms.terms_id,
+        terms.terms_desc,
+        terms.discount_pct,
+        terms.discount_days,
+        terms.net_days,
+        terms.date_last_modified AS terms_date_last_modified
+      FROM vendor
+      INNER JOIN address ON vendor.vendor_id = address.id
+      INNER JOIN terms ON vendor.default_terms_id = terms.terms_id
+      ${whereClause}
+      ORDER BY vendor.vendor_id
+      OFFSET @offset ROWS FETCH NEXT @pageSize ROWS ONLY;
+    `;
+
+    const result = await dataRequest.query(dataQuery);
+
+    const countRequest = new sql.Request();
+    if (updatedSinceDate) {
+      countRequest.input('updatedSince', sql.DateTime2, updatedSinceDate);
+    }
+    if (companyParam) {
+      countRequest.input('company', sql.VarChar, companyParam);
+    }
+
+    const countQuery = `
+      SELECT COUNT(*) AS total
+      FROM vendor
+      INNER JOIN address ON vendor.vendor_id = address.id
+      INNER JOIN terms ON vendor.default_terms_id = terms.terms_id
+      ${whereClause};
+    `;
+
+    const countResult = await countRequest.query(countQuery);
+    const total = countResult.recordset[0] ? countResult.recordset[0].total : 0;
+
+    const suppliers = result.recordset.map(formatSupplierRecord);
+
+    res.json({
+      data: suppliers,
+      page,
+      pageSize,
+      total,
+      totalPages: Math.ceil(total / pageSize)
+    });
+  } catch (error) {
+    console.error('Error fetching suppliers:', error);
+    res.status(500).json({ error: 'Failed to load suppliers' });
+  }
+});
+
+module.exports = router;

--- a/p21-api/server.js
+++ b/p21-api/server.js
@@ -15,6 +15,7 @@ app.use('/inventory', require('./routes/inventory'));
 app.use('/pricing', require('./routes/pricing'));
 // Unified orders route handles both creation (CSV export) and status lookup
 app.use('/orders', require('./routes/orders'));
+app.use('/v1/ap/suppliers', require('./routes/v1/ap/suppliers'));
 
 // DEBUG fallback route (handles unmatched routes safely)
 app.all('*', (req, res) => {


### PR DESCRIPTION
## Summary
- add a versioned `/v1/ap/suppliers` route that queries P21 vendors with pagination and filtering
- transform vendor and terms records into the Medius supplier payload shape
- document the new endpoint and response contract in the OpenAPI specification

## Testing
- node -e "require('./p21-api/routes/v1/ap/suppliers')"

------
https://chatgpt.com/codex/tasks/task_e_68d2f1c8a95083319409b951a172f9b9