### PR TITLE
Remove duplicate sales order endpoint from OpenAPI spec

### DIFF
--- a/p21-api/openapi.yaml
+++ b/p21-api/openapi.yaml
@@ -184,32 +184,6 @@ paths:
         '500':
           description: Unexpected error while inserting order records
 
-  /v1/sales/order:
-    post:
-      summary: Create sales orders in TMP_SRX tables
-      description: |
-        Accepts one or more sales orders, assigns a new `Import_Set_No` to each,
-        and inserts the header and line rows into the `TMP_SRX_Header` and
-        `TMP_SRX_Line` tables within a single SQL Server transaction. Implemented
-        in `routes/v1/sales/order.js`.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SalesOrderUpsertRequest'
-      responses:
-        '201':
-          description: Orders were stored and the generated import set numbers returned
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SalesOrderUpsertResponse'
-        '400':
-          description: Request payload failed validation
-        '500':
-          description: Unexpected error while inserting order records
-
 components:
   schemas:
     InventorySummary:


### PR DESCRIPTION
## Summary
- remove the duplicated `/v1/sales/order` path definition from the OpenAPI document to keep the spec concise

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5497d5cb48331a5355c3a2ec9991e