### PR TITLE
Ignore inbound Contract_Bin_ID and rename Requested_Date key to requiredDate in sales order route

### DIFF
--- a/routes/v1/sales/order.js
+++ b/routes/v1/sales/order.js
@@ -16,7 +16,7 @@ const headerFields = [
   { column: 'Taker', key: 'taker', type: sql.NVarChar(30) },
   { column: 'Job_Name', key: 'jobName', type: sql.NVarChar(40) },
   { column: 'Order_Date', key: 'orderDate', type: sql.NVarChar(8) },
-  { column: 'Requested_Date', key: 'requestedDate', type: sql.NVarChar(8) },
+  { column: 'Requested_Date', key: 'requiredDate', type: sql.NVarChar(8) },
   { column: 'Quote', key: 'quote', type: sql.NVarChar(1) },
   { column: 'Approved', key: 'approved', type: sql.NVarChar(1) },
   { column: 'Ship_To_ID', key: 'shipToId', type: sql.Decimal(18, 2), required: true, numeric: true },
@@ -102,9 +102,9 @@ const isEmpty = (value) => value === undefined || value === null || value === ''
 function normaliseLinePayload(line = {}) {
   const normalised = { ...line };
 
-  if (isEmpty(normalised.contractBinId) && !isEmpty(normalised.Contract_Bin_ID)) {
-    normalised.contractBinId = normalised.Contract_Bin_ID;
-  }
+  // Ignore any inbound contract bin values from either payload shape.
+  normalised.contractBinId = null;
+  delete normalised.Contract_Bin_ID;
 
   return normalised;
 }


### PR DESCRIPTION
### Motivation
- Prevent clients from setting or overriding `contractBinId` via inbound payloads for line items to avoid unintended side effects.
- Standardize the header field key for the requested date from `requestedDate` to `requiredDate` to match expected payload/column semantics.

### Description
- Renamed the header field mapping from `{ column: 'Requested_Date', key: 'requestedDate' }` to use the key `requiredDate` instead.
- Changed `normaliseLinePayload` to explicitly null out `contractBinId` and remove any `Contract_Bin_ID` property, with a comment explaining inbound values are ignored.
- Removed the previous conditional copy from `Contract_Bin_ID` into `contractBinId` so incoming values are no longer propagated.

### Testing
- Ran unit and integration tests with `npm test`, and the test suite completed successfully.
- Ran linting with `npm run lint`, and lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0372869ec8331a328d3e3edab5915)